### PR TITLE
Add payload field to Transaction model

### DIFF
--- a/models/Transaction.py
+++ b/models/Transaction.py
@@ -14,6 +14,7 @@ class Transaction(Base):
     block_time = Column(BigInteger)  # "1663286480803"
     is_accepted = Column(Boolean, default=False)
     accepting_block_hash = Column(String, nullable=True)
+    payload = Column(String, nullable=True)
 
 
 Index("block_time_idx", Transaction.block_time)


### PR DESCRIPTION
## Changes

Adds `payload` field to the `Transaction` model to align with the updated database schema.

## Context

This change synchronizes the REST API model with the htn-db-filler schema update (see [link to htn-db-filler PR]). The db-filler is now saving transaction payloads, so the REST API needs to know about this column to avoid SQLAlchemy errors and enable payload queries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Infrastructure update to support storing optional payload data with transactions. This enables richer transaction context and future features. No immediate UI changes; existing behavior and performance remain unchanged. Migration is backward-compatible and requires no action from users. APIs remain stable; historical transactions are unaffected; rollout is transparent and monitored. Availability and reliability are unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->